### PR TITLE
특수문자와 해시태그/링크가 동시에 첨부된 게시물 렌더링 오류 수정

### DIFF
--- a/components/PostView/PostText/index.tsx
+++ b/components/PostView/PostText/index.tsx
@@ -41,7 +41,7 @@ export default function PostText({
         {linkText}
       </Anchor>
     );
-    currentIndex = byteEnd;
+    currentIndex = charEnd;
   });
 
   // 마지막 링크 이후 남은 텍스트 추가
@@ -55,13 +55,17 @@ const getCharIndexFromByteIndex = (text: string, byteIndex: number): number => {
   const encoder = new TextEncoder();
   let cumulativeByteCount = 0;
   for (let i = 0; i < text.length; i++) {
-    const char = text[i];
+    // 서러게이트 쌍일 경우 두 글자를 동시에 처리
+    const char = text.charCodeAt(i) >> 10 == 54
+      ? text.slice(i, i + 2)
+      : text[i];
     const encodedChar = encoder.encode(char);
     // 만약 다음 문자를 포함하면 byteIndex가 이 문자 내에 존재함
     if (cumulativeByteCount + encodedChar.length > byteIndex) {
       return i;
     }
     cumulativeByteCount += encodedChar.length;
+    i += char.length - 1;
   }
   return text.length;
 };


### PR DESCRIPTION
기존의 코드에서 UTF-16 surrogate pair를 처리하지 않아 발생하는 게시물 렌더링 오류를 수정했습니다. (위에서부터 수정 이전/이후 렌더링; cf. <https://bsky.app/profile/eatch.dev/post/3lptmkkuy4s26>)

![수정 이전에 렌더링된 게시물. '👀👀 #다람쥐헌쳇바퀴에타고파'의 마지막 두 글자와 '§§§§§ #test §§§§§'의 공백 1글자, 섹션 기호 4글자가 누락되었다.](https://github.com/user-attachments/assets/0863043f-48d0-42ab-994a-9f5c5dce3080)
![수정 이후 렌더링된 게시물. 두 게시물이 모두 정상적으로 표시되고 있다.](https://github.com/user-attachments/assets/83bc1301-366e-4d18-b2d2-f17cd6604a70)